### PR TITLE
Use mod.conf for dependencies/name

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,0 @@
-default

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,2 @@
+name = grossdecor
+depends = default


### PR DESCRIPTION
Deletes deprecated `depends.txt`.